### PR TITLE
Add dark mode with theme toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import { Dashboard } from './components/dashboard/Dashboard';
 import { VKCallback } from './components/auth/VKCallback';
 import { YandexCallback } from './components/auth/YandexCallback';
 import { AuthForm } from './components/auth/AuthForm';
+import { ThemeProvider } from './theme';
 
 function AppRoutes() {
   const navigate = useNavigate();
@@ -20,9 +21,11 @@ function AppRoutes() {
 
 function App() {
   return (
-    <Router>
-      <AppRoutes />
-    </Router>
+    <ThemeProvider>
+      <Router>
+        <AppRoutes />
+      </Router>
+    </ThemeProvider>
   );
 }
 

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import { ThemeContext } from '../theme';
+import { Sun, Moon } from 'lucide-react';
+
+export function ThemeToggle() {
+  const { theme, toggleTheme } = useContext(ThemeContext);
+  return (
+    <button
+      onClick={toggleTheme}
+      className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
+    >
+      {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
+    </button>
+  );
+}

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -22,7 +22,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({ id, value, onChange, labe
 
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-gray-700">
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
         {label}
       </label>
       <div className="mt-1 relative rounded-md shadow-sm">
@@ -31,7 +31,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({ id, value, onChange, labe
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="block w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm pr-10"
+          className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm pr-10"
           placeholder={placeholder}
           required
         />
@@ -137,27 +137,27 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-      <div className="max-w-md w-full space-y-8 bg-white p-8 rounded-lg shadow-lg">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
           {isRegistration ? (
-            <UserPlus className="mx-auto h-12 w-12 text-gray-700" />
+            <UserPlus className="mx-auto h-12 w-12 text-gray-700 dark:text-gray-200" />
           ) : (
-            <User className="mx-auto h-12 w-12 text-gray-700" />
+            <User className="mx-auto h-12 w-12 text-gray-700 dark:text-gray-200" />
           )}
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
             {isRegistration ? 'Регистрация' : 'Вход'}
           </h2>
         </div>
 
         {/* iOS-style Toggle */}
         <div className="flex justify-center">
-          <div className="bg-gray-100 p-1 rounded-lg inline-flex">
+          <div className="bg-gray-100 dark:bg-gray-700 p-1 rounded-lg inline-flex">
             <button
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
                 !isRegistration
-                  ? 'bg-white shadow-sm text-gray-900'
-                  : 'text-gray-500 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
               }`}
               onClick={() => setIsRegistration(false)}
             >
@@ -166,8 +166,8 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
             <button
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
                 isRegistration
-                  ? 'bg-white shadow-sm text-gray-900'
-                  : 'text-gray-500 hover:text-gray-900'
+                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-gray-100'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
               }`}
               onClick={() => setIsRegistration(true)}
             >
@@ -178,10 +178,10 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
         
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-300"></div>
+            <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">или войдите через</span>
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">или войдите через</span>
           </div>
         </div>
 
@@ -197,7 +197,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
           <button
             onClick={handleVKLogin}
             disabled
-            className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium bg-gray-200 text-gray-400 cursor-not-allowed"
+            className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium bg-gray-200 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed"
           >
             <LogIn className="h-5 w-5" />
             ВКонтакте
@@ -206,28 +206,28 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
 
         <div className="relative">
           <div className="absolute inset-0 flex items-center">
-            <div className="w-full border-t border-gray-300"></div>
+            <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white text-gray-500">или заполните форму</span>
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">или заполните форму</span>
           </div>
         </div>
         
         <form className="space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative" role="alert">
+            <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 px-4 py-3 rounded relative" role="alert">
               <span className="block sm:inline">{error}</span>
             </div>
           )}
           {success && (
-            <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded relative" role="alert">
+            <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-200 px-4 py-3 rounded relative" role="alert">
               <span className="block sm:inline">{success}</span>
             </div>
           )}
           <div className="space-y-4">
             {isRegistration && (
               <div>
-                <label htmlFor="login" className="block text-sm font-medium text-gray-700">
+                <label htmlFor="login" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                   Логин
                 </label>
                 <input
@@ -235,7 +235,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
                   name="login"
                   type="text"
                   required
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
+                  className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
                   placeholder="example-login"
                   value={formData.login}
                   onChange={handleChange}
@@ -243,7 +243,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
               </div>
             )}
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
                 Email
               </label>
               <input
@@ -251,7 +251,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
                 name="email"
                 type="email"
                 required
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
                 placeholder="example@mail.ru"
                 value={formData.email}
                 onChange={handleChange}

--- a/src/components/auth/PasswordRecoveryModal.tsx
+++ b/src/components/auth/PasswordRecoveryModal.tsx
@@ -49,27 +49,27 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
 
   return (
     <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center p-4">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full">
+      <div className="bg-white dark:bg-gray-800 rounded-lg p-6 max-w-md w-full">
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-semibold">
             {step === 'code' ? 'Подтверждение кода' : 'Новый пароль'}
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700"
+            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-50 text-red-700 rounded-md">
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900 text-red-700 dark:text-red-200 rounded-md">
             {error}
           </div>
         )}
 
         {success && (
-          <div className="mb-4 p-3 bg-green-50 text-green-700 rounded-md">
+          <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-700 dark:text-green-200 rounded-md">
             {success}
           </div>
         )}
@@ -77,14 +77,14 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
         {step === 'code' ? (
           <form onSubmit={handleConfirmCode}>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Код подтверждения
               </label>
               <input
                 type="text"
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Введите код из письма"
                 required
               />
@@ -100,14 +100,14 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
         ) : (
           <form onSubmit={handleUpdatePassword}>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
                 Новый пароль
               </label>
               <input
                 type="password"
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Введите новый пароль"
                 required
                 minLength={6}

--- a/src/components/auth/RegistrationConfirmation.tsx
+++ b/src/components/auth/RegistrationConfirmation.tsx
@@ -24,13 +24,13 @@ export function RegistrationConfirmation() {
 
   if (isConfirmed) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="max-w-md w-full space-y-8 bg-white p-8 rounded-lg shadow-lg">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+        <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
           <div className="text-center">
-            <h2 className="mt-6 text-3xl font-bold text-gray-900">
+            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
               Регистрация подтверждена!
             </h2>
-            <p className="mt-2 text-sm text-gray-600">
+            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
               Теперь вы можете войти в систему
             </p>
           </div>
@@ -41,29 +41,29 @@ export function RegistrationConfirmation() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-      <div className="max-w-md w-full space-y-8 bg-white p-8 rounded-lg shadow-lg">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
             Подтверждение регистрации
           </h2>
         </div>
 
         {error && (
-          <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{error}</span>
           </div>
         )}
 
         {success && (
-          <div className="bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-200 px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{success}</span>
           </div>
         )}
 
         <form className="space-y-6" onSubmit={handleSubmit}>
           <div>
-            <label htmlFor="code" className="block text-sm font-medium text-gray-700">
+            <label htmlFor="code" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
               Код подтверждения
             </label>
             <input
@@ -71,7 +71,7 @@ export function RegistrationConfirmation() {
               name="code"
               type="text"
               required
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="Введите код из письма"
               value={code}
               onChange={(e) => setCode(e.target.value)}

--- a/src/components/auth/VKCallback.tsx
+++ b/src/components/auth/VKCallback.tsx
@@ -56,10 +56,10 @@ export function VKCallback() {
 
   if (error) {
     return (
-      <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-        <div className="max-w-md w-full space-y-8 bg-white p-8 rounded-lg shadow-lg">
+      <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+        <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
           <div className="text-center">
-            <h2 className="mt-6 text-3xl font-bold text-gray-900">Ошибка авторизации</h2>
+            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">Ошибка авторизации</h2>
             <p className="mt-2 text-sm text-red-600">{error}</p>
           </div>
           <div className="mt-8">
@@ -76,11 +76,11 @@ export function VKCallback() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center p-4">
-      <div className="max-w-md w-full space-y-8 bg-white p-8 rounded-lg shadow-lg">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
+      <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
-          <h2 className="mt-6 text-3xl font-bold text-gray-900">Авторизация</h2>
-          <p className="mt-2 text-sm text-gray-600">Пожалуйста, подождите...</p>
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">Авторизация</h2>
+          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">Пожалуйста, подождите...</p>
         </div>
       </div>
     </div>

--- a/src/components/auth/YandexCallback.tsx
+++ b/src/components/auth/YandexCallback.tsx
@@ -50,7 +50,7 @@ export function YandexCallback() {
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
         <div className="text-center">
           <div className="spinner-border text-primary" role="status">
             <span className="visually-hidden">Загрузка...</span>
@@ -63,11 +63,11 @@ export function YandexCallback() {
 
   if (error) {
     return (
-      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="flex items-center justify-center min-h-screen bg-gray-100 dark:bg-gray-900">
         <div className="text-center">
-          <div className="p-4 bg-white shadow rounded-lg">
+          <div className="p-4 bg-white dark:bg-gray-800 shadow rounded-lg">
             <h2 className="text-xl font-semibold text-red-600">Ошибка авторизации</h2>
-            <p className="mt-2 text-gray-600">{error}</p>
+            <p className="mt-2 text-gray-600 dark:text-gray-400">{error}</p>
             <button
               onClick={() => navigate('/')}
               className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -13,6 +13,7 @@ import {
   TActionGrant 
 } from '../../services/accessObjectService';
 import { useLocation } from 'react-router-dom';
+import { ThemeToggle } from '../ThemeToggle';
 
 interface UserData {
   id: string;
@@ -550,8 +551,8 @@ export function Dashboard() {
 
     return (
       <div className="overflow-x-auto">
-        <table className="min-w-full divide-y divide-gray-200">
-          <thead className="bg-gray-50">
+        <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+          <thead className="bg-gray-50 dark:bg-gray-700">
             <tr>
               <th scope="col" className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider w-1/4">
                 Объект доступа
@@ -579,9 +580,9 @@ export function Dashboard() {
               </th>
             </tr>
           </thead>
-          <tbody className="bg-white divide-y divide-gray-200">
+          <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
             {rows.map((row) => (
-              <tr key={row.id} className={`hover:bg-gray-50 ${!row.isObject ? 'bg-gray-50' : ''}`}>
+              <tr key={row.id} className={`hover:bg-gray-50 dark:hover:bg-gray-700 ${!row.isObject ? 'bg-gray-50 dark:bg-gray-700' : ''}`}>
                 <td className="px-3 py-2 whitespace-nowrap">
                   <div className="flex items-center">
                     <div style={{ marginLeft: `${row.level * 1}rem` }} className="flex items-center">
@@ -721,7 +722,7 @@ export function Dashboard() {
       const children = roleTree.filter(n => n.parentName === node.name);
       return (
         <div key={node.name} className="relative">
-          <div className="flex items-center space-x-2 p-2 bg-gray-50 rounded mb-2" style={{ marginLeft: level > 0 ? '1.5rem' : 0 }}>
+          <div className="flex items-center space-x-2 p-2 bg-gray-50 dark:bg-gray-700 rounded mb-2" style={{ marginLeft: level > 0 ? '1.5rem' : 0 }}>
             <div className="flex items-center">
               <Shield className="h-4 w-4 text-gray-400" />
               <div className="ml-2">
@@ -761,28 +762,31 @@ export function Dashboard() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-50">
+    <div className="min-h-screen bg-gray-50 dark:bg-gray-900">
       {/* Header */}
-      <header className="bg-white shadow">
+      <header className="bg-white dark:bg-gray-800 shadow">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <div className="flex items-center space-x-4">
-            <div className="h-10 w-10 rounded-full bg-gray-200 flex items-center justify-center">
-              <span className="text-gray-600 font-medium">
+            <div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
+              <span className="text-gray-600 dark:text-gray-200 font-medium">
                 {userData?.login?.[0]?.toUpperCase() || '?'}
               </span>
             </div>
             <div>
-              <h1 className="text-xl font-semibold text-gray-900">{userData?.login || 'Пользователь'}</h1>
-              <p className="text-sm text-gray-500">{userData?.email || ''}</p>
+              <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{userData?.login || 'Пользователь'}</h1>
+              <p className="text-sm text-gray-500 dark:text-gray-400">{userData?.email || ''}</p>
             </div>
           </div>
-          <button
-            onClick={handleLogout}
-            className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900"
-          >
-            <LogOut className="h-5 w-5 mr-2" />
-            Выйти
-          </button>
+          <div className="flex items-center space-x-4">
+            <ThemeToggle />
+            <button
+              onClick={handleLogout}
+              className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
+            >
+              <LogOut className="h-5 w-5 mr-2" />
+              Выйти
+            </button>
+          </div>
         </div>
       </header>
 
@@ -1046,7 +1050,7 @@ export function Dashboard() {
                   ) : (
                     <div className="mt-4 space-y-4">
                       {devices.map((device) => (
-                        <div key={device.id} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                        <div key={device.id} className="flex items-center justify-between p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
                           <div className="flex items-center space-x-4">
                             <Smartphone className="h-6 w-6 text-gray-400" />
                             <div>
@@ -1078,9 +1082,9 @@ export function Dashboard() {
           )}
 
           {activeTab === 'services' && (
-            <div className="divide-y divide-gray-200">
+            <div className="divide-y divide-gray-200 dark:divide-gray-700">
               {mockUserData.services.map((service) => (
-                <div key={service.id} className="p-6 flex items-center justify-between hover:bg-gray-50">
+                <div key={service.id} className="p-6 flex items-center justify-between hover:bg-gray-50 dark:hover:bg-gray-700">
                   <div className="flex items-center">
                     <service.icon className="h-10 w-10 text-gray-400" />
                     <div className="ml-4">
@@ -1121,7 +1125,7 @@ export function Dashboard() {
                                 setSelectedRoleForTree(role.name);
                                 fetchRoleTree(role.name);
                               }}
-                              className={`flex items-center p-3 bg-gray-50 rounded-lg cursor-pointer hover:bg-gray-100 transition-colors ${
+                              className={`flex items-center p-3 bg-gray-50 dark:bg-gray-700 rounded-lg cursor-pointer hover:bg-gray-100 dark:hover:bg-gray-600 transition-colors ${
                                 selectedRoleForTree === role.name ? 'ring-2 ring-blue-500' : ''
                               }`}
                             >
@@ -1149,7 +1153,7 @@ export function Dashboard() {
                     </div>
                   </div>
                 </div>
-                <div className="mb-6 p-4 bg-gray-50 rounded-lg">
+                <div className="mb-6 p-4 bg-gray-50 dark:bg-gray-700 rounded-lg">
                   <div className="flex flex-col sm:flex-row gap-4 items-end">
                     <div className="flex-1">
                       <label className="block text-sm font-medium text-gray-700 mb-1">Название роли</label>
@@ -1249,8 +1253,8 @@ export function Dashboard() {
                 <div className="text-center text-gray-500">Пользователи не найдены</div>
               ) : (
                 <div className="overflow-x-auto">
-                  <table className="min-w-full divide-y divide-gray-200">
-                    <thead className="bg-gray-50">
+                  <table className="min-w-full divide-y divide-gray-200 dark:divide-gray-700">
+                    <thead className="bg-gray-50 dark:bg-gray-700">
                       <tr>
                         <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">ID</th>
                         <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Логин</th>
@@ -1258,7 +1262,7 @@ export function Dashboard() {
                         <th className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Действия</th>
                       </tr>
                     </thead>
-                    <tbody className="bg-white divide-y divide-gray-200">
+                    <tbody className="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
                       {users.map(user => (
                         <tr key={user.id}>
                           <td className="px-3 py-2 whitespace-nowrap text-sm text-gray-900">{user.id}</td>

--- a/src/theme.tsx
+++ b/src/theme.tsx
@@ -1,0 +1,42 @@
+import { createContext, useState, useEffect, ReactNode } from 'react';
+
+type Theme = 'light' | 'dark';
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+export const ThemeContext = createContext<ThemeContextType>({
+  theme: 'light',
+  toggleTheme: () => {},
+});
+
+export function ThemeProvider({ children }: { children: ReactNode }) {
+  const [theme, setTheme] = useState<Theme>('light');
+
+  useEffect(() => {
+    const stored = localStorage.getItem('theme') as Theme | null;
+    if (stored) {
+      setTheme(stored);
+    } else if (window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      setTheme('dark');
+    }
+  }, []);
+
+  useEffect(() => {
+    document.documentElement.classList.remove('light', 'dark');
+    document.documentElement.classList.add(theme);
+    localStorage.setItem('theme', theme);
+  }, [theme]);
+
+  const toggleTheme = () => {
+    setTheme(prev => (prev === 'light' ? 'dark' : 'light'));
+  };
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,6 @@
 /** @type {import('tailwindcss').Config} */
 export default {
+  darkMode: 'class',
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable Tailwind dark mode
- implement a ThemeProvider and ThemeToggle component
- wrap the app with ThemeProvider
- add a theme switcher in Dashboard header
- style pages for dark theme support

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_6845a768c9c08332b02e63c7aa2a052a