### PR TITLE
Fix dark theme on dashboard

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -668,7 +668,7 @@ export function Dashboard() {
                         <MoreVertical className="h-4 w-4" />
                       </button>
                       {openMenuId === row.id && (
-                        <div className="absolute right-0 z-50 mt-2 w-40 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5">
+                        <div className="absolute right-0 z-50 mt-2 w-40 rounded-md shadow-lg bg-white dark:bg-gray-800 ring-1 ring-black dark:ring-white ring-opacity-5 dark:ring-opacity-10">
                           <div className="py-1 flex flex-col" role="menu" aria-orientation="vertical">
                             <button
                               onClick={() => handleGrantAccess(row.action.actionName)}
@@ -871,7 +871,7 @@ export function Dashboard() {
         </div>
 
         {/* Content */}
-        <div className="bg-white rounded-lg shadow">
+        <div className="bg-white dark:bg-gray-800 rounded-lg shadow">
           {activeTab === 'profile' && userData && (
             <div className="p-6">
               <div className="space-y-6">
@@ -1289,7 +1289,7 @@ export function Dashboard() {
               {/* Модальное окно для выдачи роли */}
               {assignRoleUserId && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-30">
-                  <div className="bg-white rounded-lg shadow-lg p-6 w-full max-w-sm">
+                  <div className="bg-white dark:bg-gray-800 rounded-lg shadow-lg p-6 w-full max-w-sm">
                     <h4 className="text-lg font-medium mb-4">Выдать роль пользователю</h4>
                     <div className="mb-4">
                       <label className="block text-sm font-medium text-gray-700 mb-1">Текущие роли пользователя:</label>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+body {
+  @apply text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100;
+}


### PR DESCRIPTION
## Summary
- ensure dropdown and modals use dark backgrounds
- add dark background to dashboard content container
- set default page text colors for dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6847425162148332af0ac49212d1dc33