### PR TITLE
Apply white text in dark mode

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -7,7 +7,7 @@ export function ThemeToggle() {
   return (
     <button
       onClick={toggleTheme}
-      className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
+      className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-white"
     >
       {theme === 'dark' ? <Sun className="h-5 w-5" /> : <Moon className="h-5 w-5" />}
     </button>

--- a/src/components/auth/AuthForm.tsx
+++ b/src/components/auth/AuthForm.tsx
@@ -22,7 +22,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({ id, value, onChange, labe
 
   return (
     <div>
-      <label htmlFor={id} className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+      <label htmlFor={id} className="block text-sm font-medium text-gray-700 dark:text-white">
         {label}
       </label>
       <div className="mt-1 relative rounded-md shadow-sm">
@@ -31,7 +31,7 @@ const PasswordInput: React.FC<PasswordInputProps> = ({ id, value, onChange, labe
           id={id}
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm pr-10"
+          className="block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm pr-10"
           placeholder={placeholder}
           required
         />
@@ -141,11 +141,11 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
       <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
           {isRegistration ? (
-            <UserPlus className="mx-auto h-12 w-12 text-gray-700 dark:text-gray-200" />
+            <UserPlus className="mx-auto h-12 w-12 text-gray-700 dark:text-white" />
           ) : (
-            <User className="mx-auto h-12 w-12 text-gray-700 dark:text-gray-200" />
+            <User className="mx-auto h-12 w-12 text-gray-700 dark:text-white" />
           )}
-          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-white">
             {isRegistration ? 'Регистрация' : 'Вход'}
           </h2>
         </div>
@@ -156,8 +156,8 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
             <button
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
                 !isRegistration
-                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-gray-100'
-                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-white dark:hover:text-white'
               }`}
               onClick={() => setIsRegistration(false)}
             >
@@ -166,8 +166,8 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
             <button
               className={`px-4 py-2 rounded-md text-sm font-medium transition-all duration-200 ${
                 isRegistration
-                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-gray-100'
-                  : 'text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-gray-200'
+                  ? 'bg-white dark:bg-gray-700 shadow-sm text-gray-900 dark:text-white'
+                  : 'text-gray-500 hover:text-gray-900 dark:text-white dark:hover:text-white'
               }`}
               onClick={() => setIsRegistration(true)}
             >
@@ -181,7 +181,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
             <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">или войдите через</span>
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-white">или войдите через</span>
           </div>
         </div>
 
@@ -197,7 +197,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
           <button
             onClick={handleVKLogin}
             disabled
-            className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium bg-gray-200 dark:bg-gray-700 text-gray-400 dark:text-gray-500 cursor-not-allowed"
+            className="w-full flex items-center justify-center gap-3 py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium bg-gray-200 dark:bg-gray-700 text-gray-400 dark:text-white cursor-not-allowed"
           >
             <LogIn className="h-5 w-5" />
             ВКонтакте
@@ -209,25 +209,25 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
             <div className="w-full border-t border-gray-300 dark:border-gray-600"></div>
           </div>
           <div className="relative flex justify-center text-sm">
-            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-gray-400">или заполните форму</span>
+            <span className="px-2 bg-white dark:bg-gray-800 text-gray-500 dark:text-white">или заполните форму</span>
           </div>
         </div>
         
         <form className="space-y-6" onSubmit={handleSubmit}>
           {error && (
-            <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 px-4 py-3 rounded relative" role="alert">
+            <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-white px-4 py-3 rounded relative" role="alert">
               <span className="block sm:inline">{error}</span>
             </div>
           )}
           {success && (
-            <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-200 px-4 py-3 rounded relative" role="alert">
+            <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-white px-4 py-3 rounded relative" role="alert">
               <span className="block sm:inline">{success}</span>
             </div>
           )}
           <div className="space-y-4">
             {isRegistration && (
               <div>
-                <label htmlFor="login" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                <label htmlFor="login" className="block text-sm font-medium text-gray-700 dark:text-white">
                   Логин
                 </label>
                 <input
@@ -235,7 +235,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
                   name="login"
                   type="text"
                   required
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
+                  className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
                   placeholder="example-login"
                   value={formData.login}
                   onChange={handleChange}
@@ -243,7 +243,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
               </div>
             )}
             <div>
-              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700 dark:text-white">
                 Email
               </label>
               <input
@@ -251,7 +251,7 @@ export function AuthForm({ onLoginSuccess }: AuthFormProps) {
                 name="email"
                 type="email"
                 required
-                className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
+                className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-transparent"
                 placeholder="example@mail.ru"
                 value={formData.email}
                 onChange={handleChange}

--- a/src/components/auth/PasswordRecoveryModal.tsx
+++ b/src/components/auth/PasswordRecoveryModal.tsx
@@ -56,20 +56,20 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
           </h2>
           <button
             onClick={onClose}
-            className="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200"
+            className="text-gray-500 hover:text-gray-700 dark:text-white dark:hover:text-white"
           >
             <X className="h-5 w-5" />
           </button>
         </div>
 
         {error && (
-          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900 text-red-700 dark:text-red-200 rounded-md">
+          <div className="mb-4 p-3 bg-red-50 dark:bg-red-900 text-red-700 dark:text-white rounded-md">
             {error}
           </div>
         )}
 
         {success && (
-          <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-700 dark:text-green-200 rounded-md">
+          <div className="mb-4 p-3 bg-green-50 dark:bg-green-900 text-green-700 dark:text-white rounded-md">
             {success}
           </div>
         )}
@@ -77,14 +77,14 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
         {step === 'code' ? (
           <form onSubmit={handleConfirmCode}>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-white mb-1">
                 Код подтверждения
               </label>
               <input
                 type="text"
                 value={code}
                 onChange={(e) => setCode(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Введите код из письма"
                 required
               />
@@ -100,14 +100,14 @@ export function PasswordRecoveryModal({ onClose }: PasswordRecoveryModalProps) {
         ) : (
           <form onSubmit={handleUpdatePassword}>
             <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              <label className="block text-sm font-medium text-gray-700 dark:text-white mb-1">
                 Новый пароль
               </label>
               <input
                 type="password"
                 value={newPassword}
                 onChange={(e) => setNewPassword(e.target.value)}
-                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                className="w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
                 placeholder="Введите новый пароль"
                 required
                 minLength={6}

--- a/src/components/auth/RegistrationConfirmation.tsx
+++ b/src/components/auth/RegistrationConfirmation.tsx
@@ -27,10 +27,10 @@ export function RegistrationConfirmation() {
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
           <div className="text-center">
-            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
+            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-white">
               Регистрация подтверждена!
             </h2>
-            <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">
+            <p className="mt-2 text-sm text-gray-600 dark:text-white">
               Теперь вы можете войти в систему
             </p>
           </div>
@@ -44,26 +44,26 @@ export function RegistrationConfirmation() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
       <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
-          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-white">
             Подтверждение регистрации
           </h2>
         </div>
 
         {error && (
-          <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-red-200 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-red-50 dark:bg-red-900 border border-red-200 dark:border-red-700 text-red-700 dark:text-white px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{error}</span>
           </div>
         )}
 
         {success && (
-          <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-green-200 px-4 py-3 rounded relative" role="alert">
+          <div className="bg-green-50 dark:bg-green-900 border border-green-200 dark:border-green-700 text-green-700 dark:text-white px-4 py-3 rounded relative" role="alert">
             <span className="block sm:inline">{success}</span>
           </div>
         )}
 
         <form className="space-y-6" onSubmit={handleSubmit}>
           <div>
-            <label htmlFor="code" className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+            <label htmlFor="code" className="block text-sm font-medium text-gray-700 dark:text-white">
               Код подтверждения
             </label>
             <input
@@ -71,7 +71,7 @@ export function RegistrationConfirmation() {
               name="code"
               type="text"
               required
-              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-gray-100 rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+              className="mt-1 block w-full px-3 py-2 border border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white rounded-md shadow-sm focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
               placeholder="Введите код из письма"
               value={code}
               onChange={(e) => setCode(e.target.value)}

--- a/src/components/auth/VKCallback.tsx
+++ b/src/components/auth/VKCallback.tsx
@@ -59,7 +59,7 @@ export function VKCallback() {
       <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
         <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
           <div className="text-center">
-            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">Ошибка авторизации</h2>
+            <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-white">Ошибка авторизации</h2>
             <p className="mt-2 text-sm text-red-600">{error}</p>
           </div>
           <div className="mt-8">
@@ -79,8 +79,8 @@ export function VKCallback() {
     <div className="min-h-screen bg-gray-50 dark:bg-gray-900 flex items-center justify-center p-4">
       <div className="max-w-md w-full space-y-8 bg-white dark:bg-gray-800 p-8 rounded-lg shadow-lg">
         <div className="text-center">
-          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-gray-100">Авторизация</h2>
-          <p className="mt-2 text-sm text-gray-600 dark:text-gray-400">Пожалуйста, подождите...</p>
+          <h2 className="mt-6 text-3xl font-bold text-gray-900 dark:text-white">Авторизация</h2>
+          <p className="mt-2 text-sm text-gray-600 dark:text-white">Пожалуйста, подождите...</p>
         </div>
       </div>
     </div>

--- a/src/components/auth/YandexCallback.tsx
+++ b/src/components/auth/YandexCallback.tsx
@@ -67,7 +67,7 @@ export function YandexCallback() {
         <div className="text-center">
           <div className="p-4 bg-white dark:bg-gray-800 shadow rounded-lg">
             <h2 className="text-xl font-semibold text-red-600">Ошибка авторизации</h2>
-            <p className="mt-2 text-gray-600 dark:text-gray-400">{error}</p>
+            <p className="mt-2 text-gray-600 dark:text-white">{error}</p>
             <button
               onClick={() => navigate('/')}
               className="mt-4 px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700"

--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -768,20 +768,20 @@ export function Dashboard() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4 flex items-center justify-between">
           <div className="flex items-center space-x-4">
             <div className="h-10 w-10 rounded-full bg-gray-200 dark:bg-gray-700 flex items-center justify-center">
-              <span className="text-gray-600 dark:text-gray-200 font-medium">
+              <span className="text-gray-600 dark:text-white font-medium">
                 {userData?.login?.[0]?.toUpperCase() || '?'}
               </span>
             </div>
             <div>
-              <h1 className="text-xl font-semibold text-gray-900 dark:text-gray-100">{userData?.login || 'Пользователь'}</h1>
-              <p className="text-sm text-gray-500 dark:text-gray-400">{userData?.email || ''}</p>
+              <h1 className="text-xl font-semibold text-gray-900 dark:text-white">{userData?.login || 'Пользователь'}</h1>
+              <p className="text-sm text-gray-500 dark:text-white">{userData?.email || ''}</p>
             </div>
           </div>
           <div className="flex items-center space-x-4">
             <ThemeToggle />
             <button
               onClick={handleLogout}
-              className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-gray-200 dark:hover:text-white"
+              className="flex items-center px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 dark:text-white dark:hover:text-white"
             >
               <LogOut className="h-5 w-5 mr-2" />
               Выйти

--- a/src/index.css
+++ b/src/index.css
@@ -3,5 +3,5 @@
 @tailwind utilities;
 
 body {
-  @apply text-gray-900 bg-white dark:bg-gray-900 dark:text-gray-100;
+  @apply text-gray-900 bg-white dark:bg-gray-900 dark:text-white;
 }


### PR DESCRIPTION
## Summary
- set dark mode text to white in global CSS
- use `dark:text-white` in registration confirmation
- use `dark:text-white` in auth form and callbacks
- update password recovery modal
- make dashboard text white in dark theme
- ensure theme toggle uses white text in dark mode

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684743be852c8332bb006dd11c79a0bb