### PR TITLE
Add dark theme styles to dropdown lists

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1181,7 +1181,7 @@ export function Dashboard() {
                       <select
                         value={newRoleParent}
                         onChange={e => setNewRoleParent(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
                       >
                         <option value="">Без родителя</option>
                         {roles.map(role => (
@@ -1216,7 +1216,7 @@ export function Dashboard() {
                         setSelectedRole(e.target.value);
                         fetchAccessObjects(e.target.value);
                       }}
-                      className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md"
+                      className="mt-1 block w-full pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm rounded-md dark:bg-gray-700 dark:text-white dark:border-gray-600"
                     >
                       <option value="">Выберите роль</option>
                       {roles.map((role) => (
@@ -1314,7 +1314,7 @@ export function Dashboard() {
                       <select
                         value={assignRoleName}
                         onChange={e => setAssignRoleName(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
                       >
                         <option value="">Выберите роль</option>
                         {roles.map(role => (

--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,7 @@
 body {
   @apply text-gray-900 bg-white dark:bg-gray-900 dark:text-white;
 }
+
+select {
+  @apply bg-white text-gray-900 border-gray-300 dark:bg-gray-700 dark:text-white dark:border-gray-600;
+}


### PR DESCRIPTION
## Summary
- add dark theme utility classes to select tags
- apply base dark theme styling for all `select` elements

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684f164b245883329d43e55718d2dfeb