### PR TITLE
Add 403 handling and error helper

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -122,7 +122,7 @@ export function Dashboard() {
     } catch (error: any) {
       let forbiddenMsg = null;
       if (error?.response?.status === 403) {
-        forbiddenMsg = error.response.data?.message || 'Доступ запрещен';
+        forbiddenMsg = error.response.data?.message || 'Доступ ограничен';
       }
       if (forbiddenMsg) {
         showDeviceToast(forbiddenMsg);
@@ -141,7 +141,7 @@ export function Dashboard() {
       setRoles(response.payload || []);
     } catch (error: any) {
       if (error?.response?.status === 403) {
-        showDeviceToast(error.response.data?.message || 'Доступ запрещен');
+        showDeviceToast(error.response.data?.message || 'Доступ ограничен');
         return;
       }
       setRolesError('Ошибка при загрузке ролей');
@@ -174,7 +174,7 @@ export function Dashboard() {
       }
     } catch (error: any) {
       if (error?.response?.status === 403) {
-        showDeviceToast(error.response.data?.message || 'Доступ запрещен');
+        showDeviceToast(error.response.data?.message || 'Доступ ограничен');
         return;
       }
       setAccessObjectsError('Ошибка при загрузке объектов доступа');
@@ -192,7 +192,7 @@ export function Dashboard() {
       setRoleTree(response.payload || []);
     } catch (error: any) {
       if (error?.response?.status === 403) {
-        showDeviceToast(error.response.data?.message || 'Доступ запрещен');
+        showDeviceToast(error.response.data?.message || 'Доступ ограничен');
         return;
       }
       setRoleTreeError('Ошибка при загрузке дерева ролей');
@@ -393,7 +393,7 @@ export function Dashboard() {
       await fetchAccessObjects(selectedRole);
     } catch (error: any) {
       if (error?.response?.status === 403) {
-        showDeviceToast(error.response.data?.message || 'Доступ запрещен');
+        showDeviceToast(error.response.data?.message || 'Доступ ограничен');
         return;
       }
       console.error('Ошибка при выдаче доступа:', error);
@@ -443,7 +443,7 @@ export function Dashboard() {
       await fetchAccessObjects(selectedRole);
     } catch (error: any) {
       if (error?.response?.status === 403) {
-        showDeviceToast(error.response.data?.message || 'Доступ запрещен');
+        showDeviceToast(error.response.data?.message || 'Доступ ограничен');
         return;
       }
       console.error('Ошибка при отзыве доступа:', error);

--- a/src/services/accessObjectService.ts
+++ b/src/services/accessObjectService.ts
@@ -1,5 +1,6 @@
 import axios from "axios";
 import { API_URL } from "./config";
+import { handleApiError } from './apiErrorHandler';
 
 export enum EAccessObjectType {
   APP = 'APP',
@@ -53,7 +54,7 @@ export const accessObjectService = {
       const response = await api.post('/admin/access_object/calculate_rights', { roleName });
       return response.data;
     } catch (error) {
-      throw this.handleError(error);
+      handleApiError(error, 'Ошибка при загрузке объектов доступа');
     }
   },
 
@@ -65,7 +66,7 @@ export const accessObjectService = {
       });
       return response.data;
     } catch (error) {
-      throw this.handleError(error);
+      handleApiError(error, 'Ошибка при обновлении прав доступа');
     }
   }
-}; 
+};

--- a/src/services/apiErrorHandler.ts
+++ b/src/services/apiErrorHandler.ts
@@ -1,0 +1,13 @@
+import axios, { AxiosError } from 'axios';
+
+export function handleApiError(error: unknown, defaultMessage: string): never {
+  if (axios.isAxiosError(error)) {
+    const message = error.response?.status === 403
+      ? 'Доступ ограничен'
+      : error.response?.data?.message || defaultMessage;
+    const err = new Error(message) as Error & { response?: AxiosError['response'] };
+    err.response = error.response;
+    throw err;
+  }
+  throw error;
+}

--- a/src/services/authService.ts
+++ b/src/services/authService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { handleApiError } from './apiErrorHandler';
 
 export const API_URL = 'http://localhost:3010/api/v1';
 
@@ -69,10 +70,7 @@ export const authService = {
       // Очищаем куки
       document.cookie = 'refreshToken=; path=/; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при авторизации');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при авторизации');
     }
   },
 
@@ -86,15 +84,12 @@ export const authService = {
 
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        if (error.response?.status === 401) {
-          localStorage.removeItem('accessToken');
-          localStorage.removeItem('refreshToken');
-          throw new Error('Сессия истекла. Пожалуйста, войдите снова.');
-        }
-        throw new Error(error.response?.data?.message || 'Ошибка при получении данных пользователя');
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        localStorage.removeItem('accessToken');
+        localStorage.removeItem('refreshToken');
+        throw new Error('Сессия истекла. Пожалуйста, войдите снова.');
       }
-      throw error;
+      handleApiError(error, 'Ошибка при получении данных пользователя');
     }
   },
 
@@ -107,10 +102,7 @@ export const authService = {
       });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при регистрации');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при регистрации');
     }
   },
 
@@ -121,10 +113,7 @@ export const authService = {
       });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при подтверждении регистрации');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при подтверждении регистрации');
     }
   },
 
@@ -158,7 +147,7 @@ export const authService = {
       // В любом случае очищаем токены
       localStorage.removeItem('accessToken');
       localStorage.removeItem('refreshToken');
-      throw error;
+      handleApiError(error, 'Ошибка при выходе');
     }
   },
 
@@ -167,10 +156,7 @@ export const authService = {
       const response = await api.post('/auth/password-recovery', { email });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при запросе восстановления пароля');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при запросе восстановления пароля');
     }
   },
 
@@ -179,10 +165,7 @@ export const authService = {
       const response = await api.post('/auth/confirm-password-recovery', { code });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при подтверждении кода восстановления');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при подтверждении кода восстановления');
     }
   },
 
@@ -194,10 +177,7 @@ export const authService = {
       });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при обновлении пароля');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при обновлении пароля');
     }
   },
 
@@ -207,10 +187,7 @@ export const authService = {
       await this.updatePassword(newPassword, code);
       return { success: true };
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при обновлении пароля');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при обновлении пароля');
     }
   },
 
@@ -222,10 +199,7 @@ export const authService = {
       }
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при получении ролей пользователя');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при получении ролей пользователя');
     }
   },
 
@@ -237,10 +211,7 @@ export const authService = {
       }
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при создании роли');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при создании роли');
     }
   },
 
@@ -252,10 +223,7 @@ export const authService = {
       }
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при получении списка пользователей');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при получении списка пользователей');
     }
   },
 
@@ -267,10 +235,7 @@ export const authService = {
       }
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при выдаче роли пользователю');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при выдаче роли пользователю');
     }
   },
-}; 
+};

--- a/src/services/deviceService.ts
+++ b/src/services/deviceService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { handleApiError } from './apiErrorHandler';
 
 const API_URL = 'http://localhost:3010/api/v1';
 
@@ -25,10 +26,7 @@ export const deviceService = {
       const response = await api.get('/device');
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при получении списка устройств');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при получении списка устройств');
     }
   },
 
@@ -37,10 +35,7 @@ export const deviceService = {
       const response = await api.delete('/device/delete', { data: { id: deviceId } });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при удалении устройства');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при удалении устройства');
     }
   },
 
@@ -74,10 +69,7 @@ export const deviceService = {
 
       return devicesResponse.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при удалении устройств');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при удалении устройств');
     }
   }
-}; 
+};

--- a/src/services/roleService.ts
+++ b/src/services/roleService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { handleApiError } from './apiErrorHandler';
 
 const API_URL = 'http://localhost:3010/api/v1';
 
@@ -40,10 +41,7 @@ export const roleService = {
 
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при получении списка ролей');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при получении списка ролей');
     }
   },
 
@@ -61,10 +59,7 @@ export const roleService = {
 
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при создании роли');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при создании роли');
     }
   },
 
@@ -82,10 +77,7 @@ export const roleService = {
 
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при обновлении роли');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при обновлении роли');
     }
   },
 
@@ -99,10 +91,7 @@ export const roleService = {
 
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при удалении роли');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при удалении роли');
     }
   },
 
@@ -113,10 +102,7 @@ export const roleService = {
       });
       return response.data;
     } catch (error) {
-      if (axios.isAxiosError(error)) {
-        throw new Error(error.response?.data?.message || 'Ошибка при получении дерева ролей');
-      }
-      throw error;
+      handleApiError(error, 'Ошибка при получении дерева ролей');
     }
   }
-}; 
+};


### PR DESCRIPTION
## Summary
- add `handleApiError` helper to provide common error handling
- use helper across services and keep response data
- show `Доступ ограничен` on Dashboard when API responds with 403

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6858032ac0e083328d3ac21c0875b737