### PR TITLE
Fix token usage for access object API

### DIFF
--- a/src/services/accessObjectService.ts
+++ b/src/services/accessObjectService.ts
@@ -48,6 +48,15 @@ const api = axios.create({
   }
 });
 
+// Добавляем интерцептор для автоматической вставки access token
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem('accessToken');
+  if (token) {
+    config.headers['Authorization'] = `Bearer ${token}`;
+  }
+  return config;
+});
+
 export const accessObjectService = {
   async getAccessObjectTree(roleName: string) {
     try {


### PR DESCRIPTION
## Summary
- add authorization interceptor to access object service

## Testing
- `npm run lint` *(fails: various eslint errors)*

------
https://chatgpt.com/codex/tasks/task_e_685828163ff8833285f0898aafd84914