### PR TITLE
Fix dark theme for role form inputs

### DIFF
--- a/src/components/dashboard/Dashboard.tsx
+++ b/src/components/dashboard/Dashboard.tsx
@@ -1172,7 +1172,7 @@ export function Dashboard() {
                         type="text"
                         value={newRoleName}
                         onChange={e => setNewRoleName(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
                         placeholder="Введите название роли"
                       />
                     </div>
@@ -1182,7 +1182,7 @@ export function Dashboard() {
                         type="text"
                         value={newRoleDescription}
                         onChange={e => setNewRoleDescription(e.target.value)}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500 dark:bg-gray-700 dark:text-white dark:border-gray-600"
                         placeholder="Введите описание роли"
                         required
                       />


### PR DESCRIPTION
## Summary
- ensure dark theme styling for `Название роли` and `Описание роли` inputs in dashboard

## Testing
- `npm run lint` *(fails: numerous existing lint errors)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68583ceae0288332b675f2b3a45a0d7e